### PR TITLE
Add minimal Vite setup and mock API

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>CRM</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/index.tsx"></script>
+  </body>
+</html>

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -2,7 +2,7 @@
 import { BrowserRouter } from "react-router-dom";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { Providers } from "./providers/Providers";
-import { AppRouter } from "./AppRouter";
+import { AppRouter } from "./AppRoutes";
 
 const queryClient = new QueryClient();
 

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,0 +1,7 @@
+@import url("../theme.css");
+
+body {
+  margin: 0;
+  font-family: Arial, sans-serif;
+  background: white;
+}

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,8 +1,7 @@
-// src/index.tsx
 import React from "react";
 import { createRoot } from "react-dom/client";
 import { App } from "@/app/App";
-import "@/app/globals.css"; // Подключение Tailwind-глобала и theme.css-переменных
+import "@/app/globals.css"; // Подключение глобальных стилей
 
 const rootElement = document.getElementById("root");
 if (rootElement) {

--- a/src/shared/lib/apiClient.ts
+++ b/src/shared/lib/apiClient.ts
@@ -1,7 +1,71 @@
-// src/shared/lib/apiClient.ts
-import axios from "axios";
+import { Product } from "@/entities/product";
+import { User } from "@/entities/user";
 
-export const apiClient = axios.create({
-  baseURL: import.meta.env.VITE_API_URL ?? "/api",
-  withCredentials: true,
-});
+let products: Product[] = [
+  { id: "1", name: "Товар 1", price: 100, sku: "SKU1", categoryId: null, imageUrl: undefined, inStock: 5, lowStockThreshold: 1 },
+  { id: "2", name: "Товар 2", price: 200, sku: "SKU2", categoryId: null, imageUrl: undefined, inStock: 3, lowStockThreshold: 1 },
+];
+
+let users: User[] = [
+  { id: "1", name: "Администратор", email: "admin@example.com", role: "admin" },
+  { id: "2", name: "Кассир", email: "cashier@example.com", role: "cashier" },
+];
+
+let currentUser: User | null = users[0];
+
+export const apiClient = {
+  async get(url: string) {
+    if (url === "/products") {
+      return { data: products };
+    }
+    if (url === "/users") {
+      return { data: users };
+    }
+    if (url === "/auth/me") {
+      return { data: currentUser };
+    }
+    throw new Error(`GET ${url} not implemented`);
+  },
+
+  async post(url: string, payload: any) {
+    if (url === "/auth/login") {
+      // simple auth imitation
+      const user = users.find((u) => u.email === payload.email);
+      if (!user) throw new Error("Invalid credentials");
+      currentUser = user;
+      return { data: { token: "dummy" } };
+    }
+    if (url === "/products") {
+      const newProduct: Product = {
+        id: String(Date.now()),
+        inStock: 0,
+        lowStockThreshold: 1,
+        sku: "",
+        categoryId: null,
+        imageUrl: undefined,
+        ...payload,
+      };
+      products.push(newProduct);
+      return { data: newProduct };
+    }
+    const stockMatch = url.match(/\/products\/(.*)\/stock/);
+    if (stockMatch) {
+      const prod = products.find((p) => p.id === stockMatch[1]);
+      if (!prod) throw new Error("Product not found");
+      prod.inStock += payload.qty ?? 0;
+      return { data: prod };
+    }
+    throw new Error(`POST ${url} not implemented`);
+  },
+
+  async put(url: string, payload: any) {
+    const match = url.match(/\/products\/(.*)/);
+    if (match) {
+      const prod = products.find((p) => p.id === match[1]);
+      if (!prod) throw new Error("Product not found");
+      Object.assign(prod, payload);
+      return { data: prod };
+    }
+    throw new Error(`PUT ${url} not implemented`);
+  },
+};

--- a/src/shared/router/protected Route.tsx
+++ b/src/shared/router/protected Route.tsx
@@ -1,7 +1,7 @@
 import { useQuery } from "@tanstack/react-query";
 import { useEffect } from "react";
 import { useNavigate } from "react-router-dom";
-import { apiClient } from "@/lib/api";
+import { apiClient } from "@/shared/lib";
 
 interface ProtectedRouteProps {
   children: React.ReactNode;
@@ -18,10 +18,13 @@ interface ProtectedRouteProps {
  * если роль не входит в allowedRoles → редирект на /.
  */
 export function ProtectedRoute({ children, allowedRoles }: ProtectedRouteProps) {
-  const { data: user, isLoading } = useQuery(
-    ["currentUser"],
-    apiClient.getCurrentUser,
-  );
+  const { data: user, isLoading } = useQuery({
+    queryKey: ["currentUser"],
+    queryFn: async () => {
+      const { data } = await apiClient.get("/auth/me");
+      return data;
+    },
+  });
   const navigate = useNavigate();
 
   useEffect(() => {

--- a/src/shared/ui/Modal.tsx
+++ b/src/shared/ui/Modal.tsx
@@ -1,2 +1,54 @@
-// src/shared/ui/Modal.tsx
-export { Dialog as Modal } from "@/components/ui/dialog";
+import React, { ReactNode, useContext, createContext } from "react";
+import ReactDOM from "react-dom";
+import { cn } from "@/shared/lib";
+
+type ModalContextValue = {
+  open: boolean;
+  setOpen: (open: boolean) => void;
+};
+
+const ModalContext = createContext<ModalContextValue | null>(null);
+
+interface ModalProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  children: ReactNode;
+}
+
+export function Modal({ open, onOpenChange, children }: ModalProps) {
+  return (
+    <ModalContext.Provider value={{ open, setOpen: onOpenChange }}>
+      {children}
+    </ModalContext.Provider>
+  );
+}
+
+interface TriggerProps {
+  asChild?: boolean;
+  children: React.ReactElement;
+}
+Modal.Trigger = function ModalTrigger({ asChild, children }: TriggerProps) {
+  const ctx = useContext(ModalContext)!;
+  const props = { onClick: () => ctx.setOpen(true) };
+  return asChild ? React.cloneElement(children, props) : <button {...props}>{children}</button>;
+};
+
+interface ContentProps {
+  className?: string;
+  children: ReactNode;
+}
+Modal.Content = function ModalContent({ className, children }: ContentProps) {
+  const ctx = useContext(ModalContext)!;
+  if (!ctx.open) return null;
+  return ReactDOM.createPortal(
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50">
+      <div className={cn("bg-white rounded-xl relative", className)}>
+        {children}
+        <button className="absolute top-2 right-2" onClick={() => ctx.setOpen(false)}>
+          ×
+        </button>
+      </div>
+    </div>,
+    document.body
+  );
+};

--- a/src/shared/ui/Tooltip.tsx
+++ b/src/shared/ui/Tooltip.tsx
@@ -1,0 +1,5 @@
+import { ReactNode } from "react";
+
+export function TooltipProvider({ children }: { children: ReactNode }) {
+  return <>{children}</>;
+}

--- a/src/shared/ui/index.ts
+++ b/src/shared/ui/index.ts
@@ -2,4 +2,4 @@
 export * from "./Button";
 export * from "./Card";
 export * from "./Modal";
-export * from "./Tooltip"; // добавьте, когда появится
+export * from "./Tooltip";

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from "vite";
+import path from "path";
+
+export default defineConfig({
+  resolve: {
+    alias: {
+      "@": path.resolve(__dirname, "src"),
+    },
+  },
+});


### PR DESCRIPTION
## Summary
- add `index.html` and `vite.config.ts`
- fix router import in `App.tsx`
- add global styles
- implement simple Modal and Tooltip components
- stub API client with in-memory data
- update `ProtectedRoute` to use the stub API

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840009fb17c8332a4de6762f9ffa06d