### PR TITLE
Update API test to use brand and category

### DIFF
--- a/api.test.ts
+++ b/api.test.ts
@@ -1,27 +1,41 @@
 import { expect } from "expect";
-import { createProduct, listProducts, createCategory } from "./api";
+import {
+  createProduct,
+  listProducts,
+  createCategory,
+  createBrand,
+} from "./api";
 
 async function testCreateProduct() {
   try {
-    // First create a category for testing
+    // Create brand and category required for the product
+    const brand = await createBrand({
+      name: "Test Brand",
+      description: "Test Brand Description",
+    });
+
     const category = await createCategory({
       name: "Test Category",
-      description: "Test Category Description"
+      description: "Test Category Description",
     });
-    
+
     // Test creating a product
     const product = await createProduct({
       name: "Test Product",
       description: "Test Description",
-      price: 10.99,
+      costPrice: 5.5,
+      retailPrice: 10.99,
       stock: 100,
+      brandId: brand.id,
       categoryId: category.id,
     });
 
     expect(product).toHaveProperty("id");
     expect(product.name).toBe("Test Product");
-    expect(product.price).toBe(10.99);
+    expect(product.retailPrice).toBe(10.99);
+    expect(product.costPrice).toBe(5.5);
     expect(product.stock).toBe(100);
+    expect(product.brandId).toBe(brand.id);
     expect(product.categoryId).toBe(category.id);
     
     // Test successful


### PR DESCRIPTION
## Summary
- fix product creation test
- setup brand and category before creating a product

## Testing
- `npm run lint` *(fails: ESLint couldn't find a config)*

------
https://chatgpt.com/codex/tasks/task_e_68400ba9948c83328d28f18394bd6196