### PR TITLE
Fix Docker build preinstall step

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,13 +3,19 @@ FROM node:20-alpine as builder
 
 WORKDIR /app
 
-# Install dependencies
-COPY package.json package-lock.json* tsconfig.json vite.config.ts index.html ./
-COPY prisma ./prisma
+# Copy package files and preinstall script first
+COPY package.json package-lock.json* ./
 COPY scripts ./scripts
+
+# Install dependencies which run the preinstall script
+RUN npm install
+
+# Copy the rest of the project
+COPY tsconfig.json vite.config.ts index.html ./
+COPY prisma ./prisma
 COPY src ./src
 
-RUN npm install
+# Build artifacts
 RUN npm run prisma:generate
 RUN npm run build
 

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "preinstall": "tsx scripts/preinstall.ts",
+    "preinstall": "npx --yes tsx scripts/preinstall.ts",
     "dev": "vite",
     "build": "vite build",
     "preview": "vite preview",


### PR DESCRIPTION
## Summary
- copy scripts before running npm install so preinstall can run

## Testing
- `npm run lint` *(fails: no-unused-vars and no-explicit-any)*
- `npx tsx api.test.ts` *(no output)*

------
https://chatgpt.com/codex/tasks/task_e_68403ca530688332857a0714a5b00f9c